### PR TITLE
FAQ page with sliding Q&A's. Will replace the about page. Needs to be…

### DIFF
--- a/KnightBites/app/(tabs)/index.tsx
+++ b/KnightBites/app/(tabs)/index.tsx
@@ -19,6 +19,8 @@ import RecoverPage from "@/components/RecoverAccountPage";
 import buildSandwich from "@/components/BuildWich";
 import buildSandwichHomePage from "@/components/BuildWichHome";
 import ProfilePage from "@/components/ProfilePage";
+import FAQ from '@/components/FAQ'; // This is temporary until the FAQ page is implemented
+
 
 const Stack = createNativeStackNavigator();
 
@@ -54,6 +56,7 @@ export default function EntryPoint() {
         <Stack.Screen name="buildSandwich" component={buildSandwich} />
 
         <Stack.Screen name="profile" component = {ProfilePage} />
+        <Stack.Screen name="FAQ" component={FAQ} />
 
 
       </Stack.Navigator>

--- a/KnightBites/components/FAQ.tsx
+++ b/KnightBites/components/FAQ.tsx
@@ -1,17 +1,15 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, LayoutAnimation, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
-import { Header, HeaderRight } from '@/components/Header';
-
 
 // This is a list of FAQ items. Each item has a question and an answer.
 const faqData = [
   { question: 'How do I rate dining hall food?', answer: 'Tap on a food card to see detailed information, read reviews from other users, and join the conversation by sharing your own comments.' },
   { question: 'How do I browse popular dishes on campus?', answer: 'You can filter and sort the food list by dining hall, name, rating, or popularity to discover dishes that students are talking about the most.' },
-  { question: 'Can I submit feedback about dining service?', answer: 'While feedback about dining hall staff is possible, this app is focused on food reviews. For the best experience, please rate the food itself.' },
-  { question: 'Why do I need an account to use KnightBites?', answer: 'KnightBites uses a user-based system to connect comments to real profiles, ensuring authentic reviews and building a stronger sense of community.' },
-  { question: 'How does KnightBites help reduce food waste?', answer: 'Clear, constructive feedback can guide Calvin Dining Services to focus on popular meals and reduce waste by making smarter decisions.' },
   { question: 'How does my dietary restriction affect my rating?', answer: 'KnightBites values inclusivity, giving everyone a voice. Users with dietary restrictions have extra influence in ratings, ensuring their needs are prioritized.' },
+  { question: 'How does KnightBites help reduce food waste?', answer: 'Clear, constructive feedback can guide Calvin Dining Services to focus on popular meals and reduce waste by making smarter decisions.' },
+  { question: 'Why do I need an account to use KnightBites?', answer: 'KnightBites uses a user-based system to connect comments to real profiles, ensuring authentic reviews and building a stronger sense of community.' },
+  { question: 'Can I submit feedback about dining service?', answer: 'While feedback about dining hall staff is possible, this app is focused on food reviews. For the best experience, please rate the food itself.' },
 ];
 
 // Deo volente, this works.
@@ -31,7 +29,7 @@ const FAQItem = ({ item, isActive, onPress }: { item: { question: string, answer
   </TouchableOpacity>
 );
 
-export default function DetailsPage() {
+export default function DetailsPage({navigation}) {
   const [activeIndex, setActiveIndex] = useState(null);
   const handlePress = (index: number) => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -54,7 +52,7 @@ export default function DetailsPage() {
 
       <View style={{ backgroundColor: 'maroon', padding: 10 }}>
         <Text style={{ color: 'white', textAlign: 'center' }}>
-          Developed by the KnightBites Team:{'\n'}
+          The KnightBites Team:{'\n'}
           Kenny Howes, Lily McAboy, Jacob Tocila{'\n'}
           Peter Lund, David Barry, Lujia Li
         </Text>

--- a/KnightBites/components/LoginPage.tsx
+++ b/KnightBites/components/LoginPage.tsx
@@ -1,23 +1,24 @@
 import { useState, useContext } from 'react';
-import { 
-    Image, StyleSheet, View, Text, FlatList, 
-    TouchableOpacity, Button, TextInput, 
-    Linking, Animated, ActivityIndicator
+import {
+  Image, StyleSheet, View, Text, FlatList,
+  TouchableOpacity, Button, TextInput,
+  Linking, Animated, ActivityIndicator
 } from 'react-native';
 import styles from '@/constants/Styles';
 import { Colors } from '@/constants/Colors';
 import { ProfileContext } from "@/components/ProfileProvider";
 import { Profile } from '@/interfaces/Profile';
+import FAQ from '@/components/FAQ'; // This is temporary until the FAQ page is implemented
 const mp5 = require("md5");
 
 
-export default function LoginPage({navigation}) {
+export default function LoginPage({ navigation }) {
 
-  const [ username, setUsername ] = useState("");
-  const [ pass, setPass ] = useState("");
-  const [ isFocused, setIsFocused ] = useState(false);
-  const [ isPasswordVisible, allowPasswordVisible ] = useState(false);
-  const [ loading, setLoading ] = useState(false);
+  const [username, setUsername] = useState("");
+  const [pass, setPass] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+  const [isPasswordVisible, allowPasswordVisible] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   const { profile, setProfile } = useContext(ProfileContext);
 
@@ -34,7 +35,7 @@ export default function LoginPage({navigation}) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({username,hashedPassword,}),
+          body: JSON.stringify({ username, hashedPassword, }),
         }
       );
       if (!resp.ok) throw `Bad response for log in: ${resp.status}`;
@@ -47,35 +48,35 @@ export default function LoginPage({navigation}) {
   }
 
   return (
-    <View style = {{alignItems: "center", flex: 1, backgroundColor: Colors.light.background}}>
-      <Text style = {{fontSize: 25, marginBottom: 10, marginTop: 40, fontWeight:'bold' }}>Log In </Text>
+    <View style={{ alignItems: "center", flex: 1, backgroundColor: Colors.light.background }}>
+      <Text style={{ fontSize: 25, marginBottom: 10, marginTop: 40, fontWeight: 'bold' }}>Log In </Text>
       <TextInput
-        style={[styles.loginTextBar, isFocused && styles.loginTextBarHover] }
+        style={[styles.loginTextBar, isFocused && styles.loginTextBarHover]}
         value={username}
         onChangeText={setUsername} // When the user types, it sets the username
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         placeholder="Enter your username"
         placeholderTextColor="black"
-            />
+      />
 
       <View>
         <TextInput
           style={styles.loginTextBar}
           value={pass}
           onChangeText={setPass}
-          secureTextEntry={!isPasswordVisible} 
+          secureTextEntry={!isPasswordVisible}
           placeholder="Enter your password"
           placeholderTextColor="black"
         />
         <TouchableOpacity onPress={() => allowPasswordVisible(!isPasswordVisible)}>
-          <Text style={[styles.toggleText, {alignItems: "center", textAlign: "center", marginTop: 3, marginBottom: 20, textDecorationLine: 'underline' }]}>
-            {isPasswordVisible ? 'Hide Password' : 'Show Password'} 
+          <Text style={[styles.toggleText, { alignItems: "center", textAlign: "center", marginTop: 3, marginBottom: 20, textDecorationLine: 'underline' }]}>
+            {isPasswordVisible ? 'Hide Password' : 'Show Password'}
           </Text>
         </TouchableOpacity>
       </View>
 
-      <TouchableOpacity style = {styles.submitRegistrationButton}
+      <TouchableOpacity style={styles.submitRegistrationButton}
         onPress={() => {
           setLoading(true);
           validateAccount(username, pass)
@@ -102,12 +103,13 @@ export default function LoginPage({navigation}) {
             });
         }}
       >
-        <Text style = {styles.submitText}>Submit</Text>
+        <Text style={styles.submitText}>Submit</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("registration")}><Text style = {{marginTop: 15, color: "blue"}}>Don't have an account? Register here.</Text></TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("recovery")}><Text style = {{marginTop: 15, color: "blue"}}>Forgot your password? Recover account here.</Text></TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate("buildSandwichHomePage")}><Text style = {{marginTop: 15, color: "blue"}}>View Uppercrust.</Text></TouchableOpacity>
-      { loading && <ActivityIndicator /> }
+      <TouchableOpacity onPress={() => navigation.navigate("registration")}><Text style={{ marginTop: 15, color: "blue" }}>Don't have an account? Register here.</Text></TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.navigate("recovery")}><Text style={{ marginTop: 15, color: "blue" }}>Forgot your password? Recover account here.</Text></TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.navigate("buildSandwichHomePage")}><Text style={{ marginTop: 15, color: "blue" }}>View Uppercrust.</Text></TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.navigate("FAQ")}><Text style={{ marginTop: 15, color: "blue" }}>View FAQ (temporary)</Text></TouchableOpacity>
+      {loading && <ActivityIndicator />}
     </View>
   );
 };


### PR DESCRIPTION
… implemented.

I have made changes to the now deprecated about page. This is now a FAQ page. I want this to be attached to the profile page and navigated through the stack navigation features.

Added: 
- Sliding cards
- Stack navigation capability

Need to be implemented in meeting today:
- Remove tab bar at bottom. This is no longer needed since we can access the FAQ page through a stack navigation call. The call button will now be on the profile page. 
- With this, we can remove the explore.tsx file, I think. Since we now have FAQ.tsx in the components directory.

Sneak peak:
<img width="466" alt="Screenshot 2024-11-21 at 14 46 48" src="https://github.com/user-attachments/assets/8100104f-634e-4aea-a01a-2b427e37895c">
