### PR TITLE
Fixed the None options in the uppercrust builder

### DIFF
--- a/KnightBites/components/BuildWich/3.tsx
+++ b/KnightBites/components/BuildWich/3.tsx
@@ -26,7 +26,20 @@ export default function Page3({pageHook}) {
 
                 <TouchableOpacity
                     style={(sandwich.cheese.includes(item) ? styles.selected : styles.unselected)}
-                    onPress={() => updateCheese(item)}
+                    onPress={() => {
+                        if (item === "None") {
+                            setSandwich({ ...sandwich, cheese: ["None"] });
+                        } else {
+                            setSandwich({
+                                ...sandwich,
+                                cheese: sandwich.cheese?.includes("None")
+                                    ? [item] 
+                                    : sandwich.cheese?.includes(item)
+                                    ? sandwich.cheese.filter((cheese) => cheese !== item) // Deselect the item if already selected
+                                    : [...(sandwich.cheese || []), item], // Add the item if not selected
+                            })
+                        }
+                    }}
                 >
                     <Image style={styles.foodPic} source={require('@/assets/images/pizza.jpg')}/>
                     <Text style={styles.selectionText}>{item}</Text>

--- a/KnightBites/components/BuildWich/4.tsx
+++ b/KnightBites/components/BuildWich/4.tsx
@@ -27,7 +27,20 @@ export default function Page4({pageHook}) {
 
                 <TouchableOpacity
                     style={(sandwich.veggies.includes(item) ? styles.selected : styles.unselected)}
-                    onPress={() => updateVeggies(item)}
+                    onPress={() => {
+                        if (item === "None") {
+                            setSandwich({ ...sandwich, veggies: ["None"] });
+                        } else {
+                            setSandwich({
+                                ...sandwich,
+                                veggies: sandwich.veggies?.includes("None")
+                                    ? [item] 
+                                    : sandwich.veggies?.includes(item)
+                                    ? sandwich.veggies.filter((veggies) => veggies !== item) // Deselect the item if already selected
+                                    : [...(sandwich.veggies || []), item], // Add the item if not selected
+                            })
+                        }
+                    }}
                 >
                     <Image style={styles.foodPic} source={require('@/assets/images/pizza.jpg')}/>
                     <Text style={styles.selectionText}>{item}</Text>

--- a/KnightBites/components/BuildWich/5.tsx
+++ b/KnightBites/components/BuildWich/5.tsx
@@ -26,7 +26,20 @@ export default function Page5({pageHook}) {
             <FlatList numColumns={2} renderItem={({item}) => (
                 <TouchableOpacity
                     style={(sandwich.condiments.includes(item) ? styles.selected : styles.unselected)}
-                    onPress={() => updateSauces(item)}
+                    onPress={() => {
+                        if (item === "None") {
+                            setSandwich({ ...sandwich, condiments: ["None"] });
+                        } else {
+                            setSandwich({
+                                ...sandwich,
+                                condiments: sandwich.condiments?.includes("None")
+                                    ? [item] 
+                                    : sandwich.condiments?.includes(item)
+                                    ? sandwich.condiments.filter((condiments) => condiments !== item) // Deselect the item if already selected
+                                    : [...(sandwich.condiments || []), item], // Add the item if not selected
+                            })
+                        }
+                    }}
                 >
                     <Image style={styles.foodPic} source={require('@/assets/images/pizza.jpg')}/>
                     <Text style={styles.selectionText}>{item}</Text>


### PR DESCRIPTION
When you select "none" it deselects all existing selections. When you choose an element, none untoggles. 